### PR TITLE
feat(example): show visit duration as x-axis area block

### DIFF
--- a/custom_components/the_gym_group/manifest.json
+++ b/custom_components/the_gym_group/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/codebeetl/ha-the-gym-group/issues",
     "requirements": [],
-    "version": "1.1.3"
+    "version": "1.1.4"
 }

--- a/examples/gym-busyness-card.yaml
+++ b/examples/gym-busyness-card.yaml
@@ -86,7 +86,7 @@ series:
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
         if (t > now.getTime()) return [];
         var end = t + (h[i].duration_minutes || 60) * 60000;
-        return [[t, 100], [end, 100]];
+        return [[t - 1, 0], [t, 100], [end, 100], [end + 1, 0]];
       }
       return [];
     show:
@@ -110,7 +110,7 @@ series:
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 1) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
         var end = t + (h[i].duration_minutes || 60) * 60000;
-        return [[t, 100], [end, 100]];
+        return [[t - 1, 0], [t, 100], [end, 100], [end + 1, 0]];
       }
       return [];
     show:
@@ -134,7 +134,7 @@ series:
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 2) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
         var end = t + (h[i].duration_minutes || 60) * 60000;
-        return [[t, 100], [end, 100]];
+        return [[t - 1, 0], [t, 100], [end, 100], [end + 1, 0]];
       }
       return [];
     show:
@@ -158,7 +158,7 @@ series:
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 3) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
         var end = t + (h[i].duration_minutes || 60) * 60000;
-        return [[t, 100], [end, 100]];
+        return [[t - 1, 0], [t, 100], [end, 100], [end + 1, 0]];
       }
       return [];
     show:
@@ -182,7 +182,7 @@ series:
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 4) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
         var end = t + (h[i].duration_minutes || 60) * 60000;
-        return [[t, 100], [end, 100]];
+        return [[t - 1, 0], [t, 100], [end, 100], [end + 1, 0]];
       }
       return [];
     show:

--- a/examples/gym-busyness-card.yaml
+++ b/examples/gym-busyness-card.yaml
@@ -70,8 +70,9 @@ series:
   - entity: sensor.bury_st_edmunds_last_check_in
     name: Visit (this week)
     color: "#ff8800"
-    opacity: 1.0
-    type: column
+    opacity: 0.4
+    stroke_width: 0
+    type: area
     yaxis_id: people
     data_generator: |
       var h = (entity.attributes && entity.attributes.checkin_history) || [];
@@ -84,7 +85,8 @@ series:
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 0) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
         if (t > now.getTime()) return [];
-        return [[t, Math.min(h[i].duration_minutes || 100, 100)]];
+        var end = t + (h[i].duration_minutes || 60) * 60000;
+        return [[t, 100], [end, 100]];
       }
       return [];
     show:
@@ -93,8 +95,9 @@ series:
   - entity: sensor.bury_st_edmunds_last_check_in
     name: Visit (1wk ago)
     color: "#ff8800"
-    opacity: 0.55
-    type: column
+    opacity: 0.25
+    stroke_width: 0
+    type: area
     yaxis_id: people
     data_generator: |
       var h = (entity.attributes && entity.attributes.checkin_history) || [];
@@ -106,8 +109,8 @@ series:
         if (d.getDay() !== dow) continue;
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 1) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
-        if (t > now.getTime()) return [];
-        return [[t, Math.min(h[i].duration_minutes || 100, 100)]];
+        var end = t + (h[i].duration_minutes || 60) * 60000;
+        return [[t, 100], [end, 100]];
       }
       return [];
     show:
@@ -116,8 +119,9 @@ series:
   - entity: sensor.bury_st_edmunds_last_check_in
     name: Visit (2wk ago)
     color: "#ff8800"
-    opacity: 0.3
-    type: column
+    opacity: 0.15
+    stroke_width: 0
+    type: area
     yaxis_id: people
     data_generator: |
       var h = (entity.attributes && entity.attributes.checkin_history) || [];
@@ -129,8 +133,8 @@ series:
         if (d.getDay() !== dow) continue;
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 2) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
-        if (t > now.getTime()) return [];
-        return [[t, Math.min(h[i].duration_minutes || 100, 100)]];
+        var end = t + (h[i].duration_minutes || 60) * 60000;
+        return [[t, 100], [end, 100]];
       }
       return [];
     show:
@@ -139,8 +143,9 @@ series:
   - entity: sensor.bury_st_edmunds_last_check_in
     name: Visit (3wk ago)
     color: "#ff8800"
-    opacity: 0.15
-    type: column
+    opacity: 0.08
+    stroke_width: 0
+    type: area
     yaxis_id: people
     data_generator: |
       var h = (entity.attributes && entity.attributes.checkin_history) || [];
@@ -152,8 +157,8 @@ series:
         if (d.getDay() !== dow) continue;
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 3) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
-        if (t > now.getTime()) return [];
-        return [[t, Math.min(h[i].duration_minutes || 100, 100)]];
+        var end = t + (h[i].duration_minutes || 60) * 60000;
+        return [[t, 100], [end, 100]];
       }
       return [];
     show:
@@ -162,8 +167,9 @@ series:
   - entity: sensor.bury_st_edmunds_last_check_in
     name: Visit (4wk ago)
     color: "#ff8800"
-    opacity: 0.07
-    type: column
+    opacity: 0.04
+    stroke_width: 0
+    type: area
     yaxis_id: people
     data_generator: |
       var h = (entity.attributes && entity.attributes.checkin_history) || [];
@@ -175,22 +181,14 @@ series:
         if (d.getDay() !== dow) continue;
         if (Math.round((s - new Date(d.getFullYear(), d.getMonth(), d.getDate())) / 604800000) !== 4) continue;
         var t = s.getTime() + d.getHours() * 3600000 + d.getMinutes() * 60000;
-        if (t > now.getTime()) return [];
-        return [[t, Math.min(h[i].duration_minutes || 100, 100)]];
+        var end = t + (h[i].duration_minutes || 60) * 60000;
+        return [[t, 100], [end, 100]];
       }
       return [];
     show:
       legend_value: false
       in_header: false
 apex_config:
-  plotOptions:
-    bar:
-      columnWidth: "3px"
-  tooltip:
-    x:
-      format: HH:mm
-    y:
-      formatter: "[[fn: function(val, opts) { if (opts.seriesIndex < 5) return val + ' people'; var weeksAgo = opts.seriesIndex - 5; var d = new Date(); d.setDate(d.getDate() - weeksAgo * 7); var days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']; var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']; return val + ' min (' + days[d.getDay()] + ' ' + d.getDate() + ' ' + months[d.getMonth()] + ')'; }]]"
   legend:
     show: true
     position: top


### PR DESCRIPTION
## Summary

- Replaces the narrow 3px column marker with a semi-transparent filled area spanning the full visit window (check-in to check-out)
- Duration now reads intuitively from the x-axis (time) rather than the y-axis (where minutes != people was misleading)
- Busyness lines remain visible through the fill; opacity scaled from 0.4 down to 0.04 across the four historical weeks
- Removes the `plotOptions.bar` and `tooltip` blocks which are no longer needed
- Bumps version to 1.1.4

## Implementation detail

`data_generator` returns `[[start, 100], [end, 100]]` for each visit. ApexCharts renders this as a flat-topped area fill from y=0 to y=100 spanning the visit window. `stroke_width: 0` removes the top border line, leaving a clean rectangle.

If `duration_minutes` is absent (e.g. visit still in progress), the block defaults to 60 minutes wide.

## Test plan

- [ ] Visit marker spans the correct time window on the x-axis
- [ ] Busyness lines are visible through the orange fill
- [ ] Historical visits (1-4 weeks ago) fade progressively
- [ ] No visit shown if today's visit hasn't started yet

Generated with [Claude Code](https://claude.com/claude-code)