### PR TITLE
feat: add calendar platform for gym visits and booked classes

### DIFF
--- a/custom_components/the_gym_group/calendar.py
+++ b/custom_components/the_gym_group/calendar.py
@@ -1,0 +1,131 @@
+"""Calendar platform for The Gym Group integration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import TheGymGroupActivityCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the calendar platform."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    activity_coordinator: TheGymGroupActivityCoordinator = entry_data["activity"]
+    busyness_data = entry_data["busyness"].data or {}
+    device_id = str(busyness_data.get("gymLocationId") or entry.entry_id)
+    gym_name = busyness_data.get("gymLocationName", "The Gym Group")
+
+    async_add_entities(
+        [TheGymGroupCalendarEntity(activity_coordinator, entry, device_id, gym_name)]
+    )
+
+
+def _make_visit_event(checkin: dict[str, Any]) -> CalendarEvent:
+    """Build a CalendarEvent from a parsed check-in dict."""
+    start: datetime = checkin["start"]
+    end: datetime = checkin["end"] or start + timedelta(hours=1)
+    return CalendarEvent(
+        start=start,
+        end=end,
+        summary="Gym Visit",
+        location=checkin.get("gym_name"),
+        uid=f"visit_{start.isoformat()}",
+    )
+
+
+def _make_class_event(cls: dict[str, Any], gym_name: str) -> CalendarEvent:
+    """Build a CalendarEvent from a parsed booked-class dict."""
+    start: datetime = cls["start"]
+    end: datetime = cls["end"] or start + timedelta(hours=1)
+    instructor: str = cls.get("instructor", "")
+    return CalendarEvent(
+        start=start,
+        end=end,
+        summary=cls.get("name") or "Booked Class",
+        description=instructor or None,
+        location=gym_name,
+        uid=f"class_{start.isoformat()}",
+    )
+
+
+class TheGymGroupCalendarEntity(
+    CoordinatorEntity[TheGymGroupActivityCoordinator], CalendarEntity
+):
+    """Calendar entity exposing gym visits and booked classes."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Gym Calendar"
+    _attr_icon = "mdi:calendar-account"
+
+    def __init__(
+        self,
+        coordinator: TheGymGroupActivityCoordinator,
+        config_entry: ConfigEntry,
+        device_id: str,
+        gym_name: str,
+    ) -> None:
+        """Initialise the calendar entity."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._gym_name = gym_name
+        self._attr_unique_id = f"{device_id}_calendar"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info so the entity appears on the existing device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=self._gym_name,
+            manufacturer="The Gym Group",
+            model="Unofficial integration",
+        )
+
+    def _all_events(self) -> list[CalendarEvent]:
+        """Return all known events sorted chronologically."""
+        data = self.coordinator.data or {}
+        events: list[CalendarEvent] = [
+            _make_visit_event(ci) for ci in data.get("calendar_checkins", [])
+        ] + [
+            _make_class_event(cls, self._gym_name)
+            for cls in data.get("calendar_classes", [])
+        ]
+        events.sort(key=lambda e: e.start)
+        return events
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the currently active event, or the next upcoming one."""
+        now = datetime.now(timezone.utc)
+        next_upcoming: CalendarEvent | None = None
+        for ev in self._all_events():
+            if ev.start <= now <= ev.end:
+                return ev
+            if ev.start > now and next_upcoming is None:
+                next_upcoming = ev
+        return next_upcoming
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return events overlapping the requested date range."""
+        return [
+            ev
+            for ev in self._all_events()
+            if ev.start < end_date and ev.end > start_date
+        ]

--- a/custom_components/the_gym_group/const.py
+++ b/custom_components/the_gym_group/const.py
@@ -10,7 +10,7 @@ from homeassistant.const import Platform
 DOMAIN = "the_gym_group"
 
 # The platform we are integrating with (sensor).
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.CALENDAR, Platform.SENSOR]
 
 # --- Config entry keys for the configurable transport / app-identity values.
 #

--- a/custom_components/the_gym_group/coordinator.py
+++ b/custom_components/the_gym_group/coordinator.py
@@ -152,6 +152,37 @@ class TheGymGroupActivityCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if ci.get("checkInDate", "") >= recent_cutoff
         ]
 
+        # Full 365-day check-in history for the calendar entity.
+        calendar_checkins: list[dict[str, Any]] = []
+        for ci in check_ins:
+            start_dt = _parse_checkin_dt(ci)
+            if start_dt is None:
+                continue
+            dur_ms: int = ci.get("duration", 0)
+            calendar_checkins.append({
+                "start": start_dt,
+                "end": start_dt + timedelta(milliseconds=dur_ms) if dur_ms else None,
+                "gym_name": ci.get("gymLocationName") or "The Gym Group",
+            })
+
+        # All upcoming non-cancelled booked classes for the calendar entity.
+        calendar_classes: list[dict[str, Any]] = []
+        for item in schedule_raw:
+            brief = item.get("brief", {})
+            if brief.get("cancelled", False):
+                continue
+            start_ms: int = brief.get("startDateTime", 0)
+            end_ms: int = brief.get("endDateTime", 0)
+            if not start_ms:
+                continue
+            instructor_info = brief.get("instructor") or {}
+            calendar_classes.append({
+                "start": datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc),
+                "end": datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc) if end_ms else None,
+                "name": brief.get("name") or "Booked Class",
+                "instructor": instructor_info.get("fullName") or "",
+            })
+
         return {
             "latest_checkin": _parse_checkin_dt(latest_raw),
             "latest_checkin_gym": (
@@ -163,6 +194,8 @@ class TheGymGroupActivityCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 else None
             ),
             "checkin_history": recent_checkins,
+            "calendar_checkins": calendar_checkins,
+            "calendar_classes": calendar_classes,
             "monthly_visits": len(monthly),
             "monthly_hours": round(total_ms / 3_600_000, 1),
             "next_class": _find_next_class(schedule_raw),

--- a/custom_components/the_gym_group/manifest.json
+++ b/custom_components/the_gym_group/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/codebeetl/ha-the-gym-group/issues",
     "requirements": [],
-    "version": "1.1.3"
+    "version": "1.2.0"
 }

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -2,6 +2,28 @@
 # name: test_diagnostics
   dict({
     'activity_data': dict({
+      'calendar_checkins': list([
+        dict({
+          'end': datetime.datetime(2025, 4, 1, 10, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'gym_name': 'Test Gym',
+          'start': datetime.datetime(2025, 4, 1, 9, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+        }),
+        dict({
+          'end': datetime.datetime(2025, 4, 3, 9, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+          'gym_name': 'Test Gym',
+          'start': datetime.datetime(2025, 4, 3, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+        }),
+      ]),
+      'calendar_classes': list([
+        dict({
+          'end': datetime.datetime(2286, 11, 20, 18, 46, 40, tzinfo=datetime.timezone.utc),
+          'instructor': 'Jane Smith',
+          'name': 'SGT-Functional Conditioning',
+          'start': datetime.datetime(2286, 11, 20, 17, 46, 39, tzinfo=datetime.timezone.utc),
+        }),
+      ]),
+      'checkin_history': list([
+      ]),
       'latest_checkin': datetime.datetime(2025, 4, 3, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
       'latest_checkin_duration_minutes': 90,
       'latest_checkin_gym': 'Test Gym',
@@ -28,11 +50,11 @@
       'created_at': '**REDACTED**',
       'data': dict({
         'application_name': 'The Gym Group',
-        'application_version': '6.10',
-        'application_version_code': '38',
+        'application_version': '7.4',
+        'application_version_code': '114',
         'host': 'thegymgroup.netpulse.com',
         'password': '**REDACTED**',
-        'user_agent': 'okhttp/3.12.3',
+        'user_agent': 'okhttp/4.12.0',
         'username': '**REDACTED**',
       }),
       'disabled_by': None,


### PR DESCRIPTION
Closes #3

## Summary

- New `calendar.py` platform adds a `TheGymGroupCalendarEntity` per configured account
- Shows **past gym visits** (365-day window) and **upcoming booked classes** (7-day lookahead) in the HA Calendar card
- No new API calls - data is sourced from the existing activity coordinator fetch
- `event` property returns the currently active event (e.g. you are at the gym now) or the next upcoming class
- `async_get_events` filters in memory across the stored window

## Implementation notes

The coordinator now produces two additional fields alongside the existing sensor data:
- `calendar_checkins` - all check-ins parsed to `{start, end, gym_name}`; visits with no duration default to 1 hour
- `calendar_classes` - all non-cancelled booked classes parsed to `{start, end, name, instructor}`

The calendar entity uid pattern is `{device_id}_calendar`, visit event uids are `visit_{start.isoformat()}`, class event uids are `class_{start.isoformat()}`.

## Test plan

- [ ] `calendar.test_gym_gym_calendar` entity appears after reload
- [ ] Past visits visible in HA Calendar card
- [ ] Upcoming booked classes visible in HA Calendar card
- [ ] Entity state is "active" while at the gym
- [ ] All 16 existing tests pass (`pytest tests/ --asyncio-mode=auto`)

Generated with [Claude Code](https://claude.com/claude-code)