### PR TITLE
feat: advanced transport fields use built-in defaults (v1.3.0)

### DIFF
--- a/custom_components/the_gym_group/__init__.py
+++ b/custom_components/the_gym_group/__init__.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
 
 from .api import TheGymGroupApiClient
 from .const import (
@@ -23,6 +27,39 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import TheGymGroupActivityCoordinator, TheGymGroupDataUpdateCoordinator
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate config entries to the current schema version.
+
+    V1 -> V2: strip the five advanced transport fields from entry.data so they
+    fall back to the built-in DEFAULT_* constants at runtime. This is a
+    breaking change documented in the v1.3.0 release notes: any genuine
+    non-default overrides must be re-entered via Configure after upgrading.
+    """
+    if config_entry.version == 1:
+        _LOGGER.debug("Migrating %s config entry from version 1 to 2", DOMAIN)
+        new_data = {
+            k: v
+            for k, v in config_entry.data.items()
+            if k
+            not in {
+                CONF_HOST,
+                CONF_USER_AGENT,
+                CONF_APPLICATION_NAME,
+                CONF_APPLICATION_VERSION,
+                CONF_APPLICATION_VERSION_CODE,
+            }
+        }
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, version=2
+        )
+        _LOGGER.info(
+            "Migrated %s config entry to version 2: advanced transport fields "
+            "now use built-in defaults unless explicitly overridden",
+            DOMAIN,
+        )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/the_gym_group/config_flow.py
+++ b/custom_components/the_gym_group/config_flow.py
@@ -43,6 +43,29 @@ _PASSWORD_SELECTOR = selector.TextSelector(
     selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
 )
 
+# The five transport/app-identity fields that are optional overrides.
+_ADV_CONF_KEYS = frozenset({
+    CONF_HOST,
+    CONF_USER_AGENT,
+    CONF_APPLICATION_NAME,
+    CONF_APPLICATION_VERSION,
+    CONF_APPLICATION_VERSION_CODE,
+})
+
+
+def _clean_advanced(data: dict[str, Any]) -> dict[str, Any]:
+    """Drop advanced transport fields with empty/blank values.
+
+    An empty field means "use the code default at runtime". Removing the key
+    from stored data lets async_setup_entry fall back to the current DEFAULT_*
+    constants, so updated defaults are picked up automatically on next HA start.
+    """
+    return {
+        k: v
+        for k, v in data.items()
+        if k not in _ADV_CONF_KEYS or (isinstance(v, str) and v.strip())
+    }
+
 
 def _credentials_schema(
     defaults: Mapping[str, Any],
@@ -51,8 +74,9 @@ def _credentials_schema(
 ) -> vol.Schema:
     """Build the schema used by both the user and options flows.
 
-    ``defaults`` is consulted for pre-fill values for every field. Falls back
-    to the module-level DEFAULT_* constants when a key is missing.
+    Advanced transport fields use ``suggested_value`` (not ``default``) so that
+    clearing a field submits an empty string, which ``_clean_advanced`` then
+    strips before saving. A placeholder shows the built-in default as hint text.
     """
     schema: dict[Any, Any] = {}
 
@@ -64,31 +88,37 @@ def _credentials_schema(
     schema[vol.Required(CONF_PASSWORD)] = _PASSWORD_SELECTOR
 
     schema[
-        vol.Optional(CONF_HOST, default=defaults.get(CONF_HOST, DEFAULT_HOST))
+        vol.Optional(
+            CONF_HOST,
+            description={"suggested_value": defaults.get(CONF_HOST) or ""},
+        )
     ] = str
     schema[
         vol.Optional(
-            CONF_USER_AGENT, default=defaults.get(CONF_USER_AGENT, DEFAULT_USER_AGENT)
+            CONF_USER_AGENT,
+            description={"suggested_value": defaults.get(CONF_USER_AGENT) or ""},
         )
     ] = str
     schema[
         vol.Optional(
             CONF_APPLICATION_NAME,
-            default=defaults.get(CONF_APPLICATION_NAME, DEFAULT_APPLICATION_NAME),
+            description={"suggested_value": defaults.get(CONF_APPLICATION_NAME) or ""},
         )
     ] = str
     schema[
         vol.Optional(
             CONF_APPLICATION_VERSION,
-            default=defaults.get(CONF_APPLICATION_VERSION, DEFAULT_APPLICATION_VERSION),
+            description={
+                "suggested_value": defaults.get(CONF_APPLICATION_VERSION) or ""
+            },
         )
     ] = str
     schema[
         vol.Optional(
             CONF_APPLICATION_VERSION_CODE,
-            default=defaults.get(
-                CONF_APPLICATION_VERSION_CODE, DEFAULT_APPLICATION_VERSION_CODE
-            ),
+            description={
+                "suggested_value": defaults.get(CONF_APPLICATION_VERSION_CODE) or ""
+            },
         )
     ] = str
 
@@ -130,7 +160,7 @@ async def _try_login(
 class TheGymGroupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for The Gym Group."""
 
-    VERSION = 1
+    VERSION = 2
 
     @staticmethod
     @callback
@@ -147,8 +177,9 @@ class TheGymGroupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            cleaned = _clean_advanced(user_input)
             try:
-                client = await _try_login(self.hass, user_input)
+                client = await _try_login(self.hass, cleaned)
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except CannotConnect:
@@ -160,7 +191,7 @@ class TheGymGroupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(client.user_id)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
-                    title=user_input[CONF_USERNAME], data=user_input
+                    title=cleaned[CONF_USERNAME], data=cleaned
                 )
 
         return self.async_show_form(
@@ -236,8 +267,9 @@ class TheGymGroupOptionsFlow(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            cleaned = _clean_advanced(user_input)
             try:
-                client = await _try_login(self.hass, user_input)
+                client = await _try_login(self.hass, cleaned)
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except CannotConnect:
@@ -246,7 +278,15 @@ class TheGymGroupOptionsFlow(config_entries.OptionsFlow):
                 _LOGGER.exception("Unexpected exception during reconfigure")
                 errors["base"] = "unknown"
             else:
-                new_data = {**self.config_entry.data, **user_input}
+                # Strip all advanced keys from stored data first so that a
+                # user who clears a field removes its override rather than
+                # leaving the old value from entry.data in place.
+                base = {
+                    k: v
+                    for k, v in self.config_entry.data.items()
+                    if k not in _ADV_CONF_KEYS
+                }
+                new_data = {**base, **cleaned}
 
                 # If the username now maps to a different account, keep the
                 # unique_id in sync so HA can still detect duplicates.

--- a/custom_components/the_gym_group/manifest.json
+++ b/custom_components/the_gym_group/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/codebeetl/ha-the-gym-group/issues",
     "requirements": [],
-    "version": "1.2.0"
+    "version": "1.3.0"
 }

--- a/custom_components/the_gym_group/translations/en.json
+++ b/custom_components/the_gym_group/translations/en.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "The Gym Group",
-                "description": "Please enter your login credentials for The Gym Group. The advanced fields below only need changing if the official app version has been bumped and the API starts rejecting requests.",
+                "description": "Please enter your login credentials. Leave the advanced fields blank to use the built-in defaults - only change them if the API starts rejecting requests after an app update.",
                 "data": {
                     "username": "Username (Email)",
                     "password": "Password (PIN)",
@@ -12,6 +12,13 @@
                     "application_name": "Application name",
                     "application_version": "Application version",
                     "application_version_code": "Application version code"
+                },
+                "data_description": {
+                    "host": "Leave blank to use the built-in default.",
+                    "user_agent": "Leave blank to use the built-in default.",
+                    "application_name": "Leave blank to use the built-in default.",
+                    "application_version": "Leave blank to use the built-in default.",
+                    "application_version_code": "Leave blank to use the built-in default."
                 }
             },
             "reauth": {
@@ -37,7 +44,7 @@
         "step": {
             "init": {
                 "title": "Update The Gym Group Configuration",
-                "description": "Update your stored credentials and (optionally) the transport / app-identity fields used to talk to the API.",
+                "description": "Update your stored credentials. Leave the advanced fields blank to use the integration's built-in defaults, which update automatically when a new version ships.",
                 "data": {
                     "username": "Username (Email)",
                     "password": "Password (PIN)",
@@ -46,6 +53,13 @@
                     "application_name": "Application name",
                     "application_version": "Application version",
                     "application_version_code": "Application version code"
+                },
+                "data_description": {
+                    "host": "Leave blank to use the built-in default.",
+                    "user_agent": "Leave blank to use the built-in default.",
+                    "application_name": "Leave blank to use the built-in default.",
+                    "application_version": "Leave blank to use the built-in default.",
+                    "application_version_code": "Leave blank to use the built-in default."
                 }
             }
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 @pytest.fixture
 async def loaded_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Set up and load the integration; return the config entry."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, version=2)
     entry.add_to_hass(hass)
     with (
         patch(

--- a/tests/const.py
+++ b/tests/const.py
@@ -2,29 +2,11 @@
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from custom_components.the_gym_group.const import (
-    CONF_APPLICATION_NAME,
-    CONF_APPLICATION_VERSION,
-    CONF_APPLICATION_VERSION_CODE,
-    CONF_HOST,
-    CONF_USER_AGENT,
-    DEFAULT_APPLICATION_NAME,
-    DEFAULT_APPLICATION_VERSION,
-    DEFAULT_APPLICATION_VERSION_CODE,
-    DEFAULT_HOST,
-    DEFAULT_USER_AGENT,
-)
-
-# Includes every key the schema collects so equality assertions against
-# entry.data / submitted form data hold after voluptuous fills defaults.
+# Minimal config stored in a v2 entry - advanced transport fields are absent,
+# meaning the integration uses its built-in DEFAULT_* constants at runtime.
 MOCK_CONFIG = {
     CONF_USERNAME: "test@email.com",
     CONF_PASSWORD: "test_password",
-    CONF_HOST: DEFAULT_HOST,
-    CONF_USER_AGENT: DEFAULT_USER_AGENT,
-    CONF_APPLICATION_NAME: DEFAULT_APPLICATION_NAME,
-    CONF_APPLICATION_VERSION: DEFAULT_APPLICATION_VERSION,
-    CONF_APPLICATION_VERSION_CODE: DEFAULT_APPLICATION_VERSION_CODE,
 }
 
 MOCK_USER_ID = "mock-user-id-123"

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -49,12 +49,7 @@
     'config_entry': dict({
       'created_at': '**REDACTED**',
       'data': dict({
-        'application_name': 'The Gym Group',
-        'application_version': '7.4',
-        'application_version_code': '114',
-        'host': 'thegymgroup.netpulse.com',
         'password': '**REDACTED**',
-        'user_agent': 'okhttp/4.12.0',
         'username': '**REDACTED**',
       }),
       'disabled_by': None,
@@ -71,7 +66,7 @@
       'source': 'user',
       'title': 'Mock Title',
       'unique_id': None,
-      'version': 1,
+      'version': 2,
     }),
   })
 # ---

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,11 +3,18 @@
 from unittest.mock import AsyncMock, patch
 
 from custom_components.the_gym_group.api import InvalidAuth
-from custom_components.the_gym_group.const import DOMAIN
+from custom_components.the_gym_group.const import (
+    CONF_APPLICATION_NAME,
+    CONF_APPLICATION_VERSION,
+    CONF_APPLICATION_VERSION_CODE,
+    CONF_HOST,
+    CONF_USER_AGENT,
+    DOMAIN,
+)
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -49,7 +56,9 @@ async def test_full_user_flow_success(
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == MOCK_CONFIG[CONF_USERNAME]
+    # Advanced fields were not submitted, so they must not be stored.
     assert result2["data"] == MOCK_CONFIG
+    assert CONF_HOST not in result2["data"]
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -226,7 +235,7 @@ async def test_options_flow_success(
 async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
     """Test options flow with invalid credentials."""
     mock_entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_CONFIG, unique_id=MOCK_USER_ID
+        domain=DOMAIN, data=MOCK_CONFIG, unique_id=MOCK_USER_ID, version=2
     )
     mock_entry.add_to_hass(hass)
 
@@ -245,3 +254,89 @@ async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
         )
     assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_migration_v1_to_v2(hass: HomeAssistant) -> None:
+    """Advanced transport fields are stripped from v1 entries on upgrade."""
+    old_data = {
+        CONF_USERNAME: "test@email.com",
+        CONF_PASSWORD: "test_password",
+        CONF_HOST: "thegymgroup.netpulse.com",
+        CONF_USER_AGENT: "okhttp/3.12.3",
+        CONF_APPLICATION_NAME: "The Gym Group",
+        CONF_APPLICATION_VERSION: "6.10",
+        CONF_APPLICATION_VERSION_CODE: "38",
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=old_data, version=1)
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_get_busyness",
+            return_value=MOCK_API_DATA,
+        ),
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_get_checkin_history",
+            return_value=MOCK_CHECKIN_HISTORY_DATA,
+        ),
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_get_schedule",
+            return_value=MOCK_SCHEDULE_DATA,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.version == 2
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.data[CONF_USERNAME] == "test@email.com"
+    assert entry.data[CONF_PASSWORD] == "test_password"
+    assert CONF_HOST not in entry.data
+    assert CONF_USER_AGENT not in entry.data
+    assert CONF_APPLICATION_NAME not in entry.data
+    assert CONF_APPLICATION_VERSION not in entry.data
+    assert CONF_APPLICATION_VERSION_CODE not in entry.data
+
+
+async def test_options_flow_explicit_override_stored(
+    hass: HomeAssistant, loaded_entry: MockConfigEntry
+) -> None:
+    """A filled advanced field is stored as an override; a cleared one is not."""
+    entry = loaded_entry
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with (
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_login",
+            return_value=True,
+        ),
+        patch("homeassistant.config_entries.ConfigEntries.async_reload"),
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_get_busyness",
+            return_value=MOCK_API_DATA,
+        ),
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_get_checkin_history",
+            return_value=MOCK_CHECKIN_HISTORY_DATA,
+        ),
+        patch(
+            "custom_components.the_gym_group.api.TheGymGroupApiClient.async_get_schedule",
+            return_value=MOCK_SCHEDULE_DATA,
+        ),
+    ):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "test@email.com",
+                CONF_PASSWORD: "test_password",
+                CONF_HOST: "custom.netpulse.com",  # explicit override
+                CONF_USER_AGENT: "",               # cleared - should not be stored
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_HOST] == "custom.netpulse.com"
+    assert CONF_USER_AGENT not in entry.data
+    assert CONF_APPLICATION_NAME not in entry.data


### PR DESCRIPTION
## Summary

- Advanced transport fields (`API host`, `User-Agent`, `Application name/version/version code`) are now optional overrides rather than always-stored values
- Leaving a field blank means "use the code default at runtime" — updated defaults ship automatically without any user action
- Config entry `VERSION` bumped from 1 to 2

## Breaking change

**Config entry migration (V1 → V2):** On first boot after upgrading, all five advanced transport fields are stripped from every stored config entry. Entries that were using default values will now pick up the current built-in defaults automatically going forward.

If you had a **genuine non-default override** (e.g. a custom API host), it will be lost and must be re-entered via **Settings → Devices & services → The Gym Group → Configure** after upgrading.

Note this in the v1.3.0 release notes so it shows in HACS.

## Changes

| File | Change |
|---|---|
| `config_flow.py` | `_clean_advanced()` strips empty fields before save; schema uses `suggested_value` not `default`; `VERSION = 2` |
| `__init__.py` | `async_migrate_entry()` V1→V2 strips the five advanced keys |
| `manifest.json` | `1.2.0` → `1.3.0` |
| `translations/en.json` | Updated descriptions + `data_description` per field |
| `tests/` | Updated fixtures, added migration test, added explicit-override test, regenerated snapshot |

## Test plan

- [x] 18 tests pass (1 pre-existing aiohttp teardown ERROR unrelated to this change)
- [x] `test_migration_v1_to_v2` — V1 entry with all five old fields → migrated to V2 with fields absent
- [x] `test_options_flow_explicit_override_stored` — filled field stored; cleared field not stored
- [x] Diagnostics snapshot updated to reflect V2 entry with no advanced fields in data

🤖 Generated with [Claude Code](https://claude.ai/claude-code)