### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/custom_components/the_gym_group/manifest.json
+++ b/custom_components/the_gym_group/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/codebeetl/ha-the-gym-group/issues",
     "requirements": [],
-    "version": "1.3.0"
+    "version": "1.3.1"
 }


### PR DESCRIPTION
Version bump for the advanced field hint text fix (PR #8).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)