### PR TITLE
fix: bump default app version to 7.7/121 to match current APK

### DIFF
--- a/custom_components/the_gym_group/const.py
+++ b/custom_components/the_gym_group/const.py
@@ -30,8 +30,8 @@ CONF_APPLICATION_VERSION_CODE = "application_version_code"
 DEFAULT_HOST = "thegymgroup.netpulse.com"
 DEFAULT_USER_AGENT = "okhttp/4.12.0"
 DEFAULT_APPLICATION_NAME = "The Gym Group"
-DEFAULT_APPLICATION_VERSION = "7.4"
-DEFAULT_APPLICATION_VERSION_CODE = "114"
+DEFAULT_APPLICATION_VERSION = "7.7"
+DEFAULT_APPLICATION_VERSION_CODE = "121"
 
 # --- API path templates (the host is supplied at runtime).
 LOGIN_PATH = "/np/exerciser/login"

--- a/custom_components/the_gym_group/manifest.json
+++ b/custom_components/the_gym_group/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/codebeetl/ha-the-gym-group/issues",
     "requirements": [],
-    "version": "1.4.0"
+    "version": "1.4.1"
 }


### PR DESCRIPTION
## Summary
- Reversed the current `The Gym Group` APKPure build (v7.7, versionCode 121) to check for API drift.
- Host (`thegymgroup.netpulse.com`), all three endpoints we use (login, gym-busyness, check-ins/history, schedule), header names, and the `okhttp/4.12.0` user-agent are all unchanged from what our client already sends.
- Only the app's own version identifiers moved (7.4/114 → 7.7/121), so this bumps `DEFAULT_APPLICATION_VERSION`/`DEFAULT_APPLICATION_VERSION_CODE` in `const.py` to match, keeping the client's advertised app version current.

## Test plan
- [x] `pytest tests/ --asyncio-mode=auto` — same 6 pre-existing failures/1 error as on `main` (sandbox HA install is frozen below the 2026.3.0 floor per the cf1d381 commit notes), no new failures introduced.
- [x] Confirmed no tests hardcode the old `7.4`/`114` default values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)